### PR TITLE
chore(mi): initial wrapper

### DIFF
--- a/internal/openvpn/mi/connectionListener.go
+++ b/internal/openvpn/mi/connectionListener.go
@@ -1,0 +1,32 @@
+package mi
+
+import (
+	"bufio"
+	"net"
+
+	"github.com/sirupsen/logrus"
+)
+
+// CreateConnectionListener dispatches events and replies
+func CreateConnectionListener(conn net.Conn, events chan []byte, replies chan []byte) {
+	scanner := bufio.NewScanner(conn)
+
+	for scanner.Scan() {
+		buffer := scanner.Bytes()
+
+		if buffer[0] == '>' {
+			events <- buffer
+		} else {
+			replies <- buffer
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		errorMessage := "Scanner Error"
+		logrus.Fatal(errorMessage)
+		events <- []byte(errorMessage)
+	}
+
+	close(events)
+	close(replies)
+}

--- a/internal/openvpn/mi/mi.go
+++ b/internal/openvpn/mi/mi.go
@@ -26,12 +26,12 @@ type (
 
 // New instantiates a management interface
 func New(port string) (*ManagementInterface, error) {
-	conn, err := net.Dial("tcp", port) // tcp vs unix
+	conn, err := net.Dial("tcp", port) // TODO: tcp vs unix
 	if err != nil {
 		return nil, err
 	}
 
-	// conn.SetWriteDeadline(time.Time{})
+	// TODO: conn.SetWriteDeadline(time.Time{})
 
 	replies := make(chan []byte, 2)
 	events := make(chan []byte, 2)

--- a/internal/openvpn/mi/mi.go
+++ b/internal/openvpn/mi/mi.go
@@ -1,0 +1,69 @@
+package mi
+
+import (
+	"fmt"
+	"net"
+)
+
+/**
+mi stands for Management Interface
+*/
+
+const (
+	outputSuccess = "SUCCESS: "
+	outputError   = "ERROR: "
+	outputEnd     = "END"
+)
+
+type (
+	// ManagementInterface structure
+	ManagementInterface struct {
+		client  net.Conn
+		replies <-chan []byte
+		events  <-chan []byte
+	}
+)
+
+// New instantiates a management interface
+func New(port string) (*ManagementInterface, error) {
+	conn, err := net.Dial("tcp", port) // tcp vs unix
+	if err != nil {
+		return nil, err
+	}
+
+	// conn.SetWriteDeadline(time.Time{})
+
+	replies := make(chan []byte, 2)
+	events := make(chan []byte, 2)
+
+	go CreateConnectionListener(conn, events, replies)
+
+	return &ManagementInterface{
+		client:  conn,
+		events:  events,
+		replies: replies,
+	}, nil
+}
+
+// GetHelp maps to help
+func (mi *ManagementInterface) GetHelp() ([]byte, error) {
+	return mi.write([]byte("help \n"))
+}
+
+func (mi *ManagementInterface) write(cmd []byte) ([]byte, error) {
+	_, err := mi.client.Write(cmd)
+	if err != nil {
+		return nil, err
+	}
+
+	return mi.read()
+}
+
+func (mi *ManagementInterface) read() ([]byte, error) {
+	reply, ok := <-mi.replies
+	if !ok {
+		return nil, fmt.Errorf("Reply channel closed while awaiting")
+	}
+
+	return reply, nil
+}

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"os"
 
+	"github.com/freemiumvpn/fpn-openvpn-server/internal/openvpn/mi"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli/v2"
 )
@@ -12,10 +13,22 @@ const (
 	appDescription = "openvpn wrapper"
 )
 
+var (
+	flags = []cli.Flag{
+		&cli.StringFlag{
+			Name:    "management-interface-port",
+			Usage:   "Management Interface Port",
+			EnvVars: []string{"MANAGEMENT_INTERFACE_PORT"},
+			Value:   ":5555",
+		},
+	}
+)
+
 func main() {
 	app := cli.NewApp()
 	app.Name = appName
 	app.Description = appDescription
+	app.Flags = flags
 	app.Action = appAction
 
 	err := app.Run(os.Args)
@@ -25,5 +38,14 @@ func main() {
 }
 
 func appAction(ctx *cli.Context) error {
+	port := ctx.String("management-interface-port")
+	managementInterface, err := mi.New(port)
+	if err != nil {
+		return err
+	}
+
+	reply, err := managementInterface.GetHelp()
+	println("reply from server=", string(reply))
+
 	return nil
 }


### PR DESCRIPTION
## Summary
- creates initial  Management Interface wrapper
- outputs openvpn help message

```
reply from server= 
Management Interface for OpenVPN 2.4.9 x86_64-alpine-linux-musl [SSL (OpenSSL)] [LZO] [LZ4] [EPOLL] [MH/PKTINFO] [AEAD] built on Apr 20 2020
```

## What's next
- wrapper should translate to a define rpc